### PR TITLE
chore: add release skill

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.PAT }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: release
+description: Prepare and publish a new Android Password Store release. Use when the user asks to release, cut a release, publish a new version, or tag a release.
+---
+
+## Purpose
+
+Release a new version of Android Password Store using the existing version file, curated changelog, auto-tag workflow, and release workflow.
+
+## When to use
+
+Use this skill when:
+- The user asks to release a new Android Password Store version
+- The user asks to cut or publish a release
+- The user asks to clear a snapshot version and tag a release
+
+Do not use this for one-time release pipeline setup. Use `setup-android-release` for setup work.
+
+## Prerequisites
+
+Before releasing, verify:
+
+1. **Working tree is clean** -- no uncommitted changes except user-approved release edits
+2. **You are on `main`** -- releases happen from main
+3. **Local main is up to date with origin/main**
+4. **No commits ahead of origin/main** unless preparing the release branch/commit intentionally
+5. **Repository has enough history and tags** to compare against the latest release tag
+
+If the checkout was fetched with only the latest commit, fetch history and tags before reviewing commits:
+
+```bash
+git rev-parse --is-shallow-repository
+git fetch --unshallow origin  # only if shallow
+git fetch --tags origin
+```
+
+## Release Process
+
+### Step 1: Verify State
+
+```bash
+git checkout main
+git pull origin main
+git status --short
+git tag --sort=-creatordate | head -3
+```
+
+If the repo is shallow, unshallow it before using `git log` for release notes.
+
+### Step 2: Determine Version
+
+Read the current version:
+
+```bash
+grep 'versioning-plugin.versionName' app/version.properties
+```
+
+Release versions must not contain `-SNAPSHOT` or another pre-release suffix. The auto-tag workflow skips snapshot/pre-release versions.
+
+### Step 3: Review Changes Since Last Release
+
+```bash
+LATEST_TAG=$(git tag --sort=-creatordate | head -1)
+git log --oneline "$LATEST_TAG"..HEAD --no-merges
+```
+
+Ensure every user-facing change is represented in `CHANGELOG.md`. Dependency bumps can be grouped if they are not individually user-facing.
+
+### Step 4: Update CHANGELOG.md
+
+1. Review the `[Unreleased]` section.
+2. Move entries into a new release section:
+   ```markdown
+   ## [<version>] - YYYY-MM-DD
+   ```
+3. Add a new empty `## [Unreleased]` section above the release section.
+4. Keep fork/CI/signing-only changes in a `### Fork infrastructure` subsection when relevant.
+
+### Step 5: Clear Snapshot Version
+
+```bash
+./gradlew :app:clearPreRelease
+```
+
+Verify `app/version.properties` version matches the changelog release section exactly.
+
+### Step 6: Commit And Push Release
+
+```bash
+VERSION=$(grep 'versioning-plugin.versionName' app/version.properties | cut -d= -f2 | tr -d '[:space:]')
+git add app/version.properties CHANGELOG.md
+git commit -m "release: $VERSION"
+git push origin main
+```
+
+The auto-tag workflow runs only when `app/version.properties` changes on `main` and the version is not a snapshot/pre-release.
+
+### Step 7: Monitor Tag And Release Workflows
+
+```bash
+gh run list --limit 5
+```
+
+Expected flow:
+
+1. `auto-tag.yml` creates signed tag `v<VERSION>`.
+2. `release.yml` builds the signed APK.
+3. `release.yml` publishes GitHub Release `v<VERSION>` using the matching `CHANGELOG.md` entry.
+
+Do not manually create tags. CI handles tags and releases.
+
+### Step 8: Start Next Development Cycle
+
+After the release is published:
+
+```bash
+./gradlew :app:bumpSnapshot
+```
+
+Ensure `CHANGELOG.md` still has an empty `## [Unreleased]` section, then commit:
+
+```bash
+NEXT_VERSION=$(grep 'versioning-plugin.versionName' app/version.properties | cut -d= -f2 | tr -d '[:space:]')
+git add app/version.properties CHANGELOG.md
+git commit -m "chore: start $NEXT_VERSION"
+git push origin main
+```
+
+## What Not To Do
+
+| Mistake | Why it's wrong | Fix |
+|---------|---------------|-----|
+| Releasing with `-SNAPSHOT` in version | Auto-tag skips snapshots | Run `./gradlew :app:clearPreRelease` |
+| Version/changelog mismatch | Release workflow cannot find notes | Match `app/version.properties` and `CHANGELOG.md` section |
+| Manually creating tags | Auto-tag creates signed tags | Push the release commit to main |
+| Skipping history/tag fetch in a shallow checkout | Commit review misses changes | Fetch full history/tags first |
+| Committing version without changelog | Release notes are incomplete | Commit both files together |
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `app/version.properties` | Version source for auto-tag and release workflows |
+| `CHANGELOG.md` | Curated release notes read by release workflow |
+| `.github/workflows/auto-tag.yml` | Creates signed tag on release version push |
+| `.github/workflows/release.yml` | Builds signed APK and creates GitHub Release |
+| `.opencode/skills/setup-android-release/SKILL.md` | One-time release pipeline setup guidance |
+
+## Checklist
+
+- [ ] On `main`, clean working tree
+- [ ] Pulled latest `origin/main`
+- [ ] Repository has full history/tags if using git log for release notes
+- [ ] Reviewed commits since latest tag
+- [ ] Updated `CHANGELOG.md` release section
+- [ ] Ran `./gradlew :app:clearPreRelease`
+- [ ] Verified version matches changelog section
+- [ ] Committed `app/version.properties` and `CHANGELOG.md` together
+- [ ] Pushed to main
+- [ ] Confirmed auto-tag and release workflows passed
+- [ ] Ran `./gradlew :app:bumpSnapshot` and committed next snapshot

--- a/.opencode/skills/setup-android-release/SKILL.md
+++ b/.opencode/skills/setup-android-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-android-release
-description: Set up automated GitHub Actions release pipeline for Android apps with signed APKs, GPG-signed tags, and auto-tagging from version files.
+description: Set up automated GitHub Actions release pipeline for Android apps with signed APKs, GPG-signed tags, and auto-tagging from version files. Use for one-time setup, not routine release cuts.
 ---
 
 ## Purpose
@@ -15,8 +15,8 @@ Set up a two-stage CI release pipeline for Android projects:
 - User wants GitHub Releases with signed APKs
 - User wants automatic tagging when version changes
 - User mentions "release pipeline", "release workflow", or "auto-tag"
-- User asks to "release", "cut a release", "publish a new version", or "tag a release"
-- User mentions bumping version, clearing snapshot, or preparing a release
+- User asks to create, fix, or redesign the release automation itself
+- User asks about required signing/GPG/PAT secrets for the Android release pipeline
 
 ## Pre-release checklist (MANDATORY before pushing)
 
@@ -140,7 +140,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.PAT }}
           fetch-depth: 0
@@ -201,7 +201,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary
- add a day-to-day release skill for Android Password Store
- narrow the existing setup-android-release skill to setup-only usage
- update release workflow checkout actions to v7

## Verification
- git diff --check

## Notes
- Existing untracked screenshot files in the working tree were not included.
