### PR TITLE
fix: prevent crash on empty biometrics/PIN timeout preference

### DIFF
--- a/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
+++ b/app/src/main/java/app/passwordstore/ui/crypto/BasePGPActivity.kt
@@ -624,7 +624,7 @@ open class BasePGPActivity : AppCompatActivity() {
     val biometrics_and_pin_last_use =
       persistentPassphrases.getLong(PreferenceKeys.BIOMETRICS_AND_PIN_LAST_USE, 0L)
     val biometrics_and_pin_timeout =
-      settings.getString(PreferenceKeys.BIOMETRICS_AND_PIN_TIMEOUT)?.toLong() ?: 3L
+      settings.getString(PreferenceKeys.BIOMETRICS_AND_PIN_TIMEOUT)?.toLongOrNull() ?: 3L
     if (
       biometrics_and_pin_timeout > 0L &&
         now - biometrics_and_pin_last_use >= TimeUnit.DAYS.toMillis(biometrics_and_pin_timeout)


### PR DESCRIPTION
## Summary

Opening any password entry crashed with `NumberFormatException` when the `biometrics_and_pin_timeout` preference was persisted as an empty string rather than null.

`String.toLong()` throws on `""`, and the `?:` elvis operator only substitutes a default on null — not on a thrown exception — so `getPersistentAndDecrypt()` crashed unconditionally whenever that preference was `""`. This is easy to hit because `BIOMETRICS_AND_PIN_TIMEOUT` is defined as a plain `editText(...)` preference with no default value and no input validation.

Fix: use `.toLongOrNull() ?: 3L`, matching the existing safe pattern used for the sibling `GENERAL_SHOW_TIME` preference two lines above in the same file.

Closes #3

## Test plan

- [x] Built a debug APK with the fix and installed it over the crashing build
- [x] Reproduced the original crash steps (open any password entry) — `DecryptActivity` now opens without crashing, confirmed via logcat (no `FATAL EXCEPTION`, process stays alive)